### PR TITLE
Utf8 pragma

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl extension Date-Holidays-KR
 
 {{$NEXT}}
+        - Add utf8 pragma
 
 0.06 2016-01-05T07:52:05Z
         - Add holiday(Day of Hangul)

--- a/Changes
+++ b/Changes
@@ -9,7 +9,7 @@ Revision history for Perl extension Date-Holidays-KR
 0.05 2013-08-01T14:09:12Z
         - Fix http://www.cpantesters.org/cpan/report/0bab814a-f52b-11e2-9591-b4ba88f30751
         - Use Minilla
-        
+
 0.0402  Wed Feb 29 18:00:00 2012 KST
         - DRY
 

--- a/lib/Date/Holidays/KR.pm
+++ b/lib/Date/Holidays/KR.pm
@@ -1,4 +1,5 @@
 package Date::Holidays::KR;
+use utf8;
 use strict;
 use warnings;
 use base 'Exporter';

--- a/lib/Date/Holidays/KR.pm
+++ b/lib/Date/Holidays/KR.pm
@@ -45,7 +45,7 @@ sub is_lunar_holiday {
     my ($year, $month, $day) = @_;
     defined $year  || return;
     defined $month || return;
-    defined $day   || return; 
+    defined $day   || return;
 
     my ($ly, $lm, $ld, $leap) = sol2lun($year, $month, $day);
 
@@ -131,7 +131,7 @@ Date::Holidays::KR - Determine Korean public holidays
 
 =head1 DESCRIPTION
 
-Date::Holidays::KR determines public holidays for Korean. 
+Date::Holidays::KR determines public holidays for Korean.
 
 =head1 FUNCTION
 

--- a/t/01_check.t
+++ b/t/01_check.t
@@ -1,3 +1,4 @@
+use utf8;
 use strict;
 
 BEGIN { $ENV{TZ} = 'Asia/Seoul' } 

--- a/t/01_check.t
+++ b/t/01_check.t
@@ -1,7 +1,7 @@
 use utf8;
 use strict;
 
-BEGIN { $ENV{TZ} = 'Asia/Seoul' } 
+BEGIN { $ENV{TZ} = 'Asia/Seoul' }
 
 use Date::Holidays::KR;
 use Test::More;

--- a/t/02_korean_new_year.t
+++ b/t/02_korean_new_year.t
@@ -1,7 +1,7 @@
 use utf8;
 use strict;
 use DateTime;
-BEGIN { $ENV{TZ} = 'Asia/Seoul' } 
+BEGIN { $ENV{TZ} = 'Asia/Seoul' }
 
 use Date::Holidays::KR;
 use Test::More tests => 24 * 3;

--- a/t/02_korean_new_year.t
+++ b/t/02_korean_new_year.t
@@ -1,3 +1,4 @@
+use utf8;
 use strict;
 use DateTime;
 BEGIN { $ENV{TZ} = 'Asia/Seoul' } 

--- a/t/03_holidays.t
+++ b/t/03_holidays.t
@@ -1,8 +1,8 @@
+use utf8;
 use strict;
 use DateTime;
 use Date::Holidays::KR;
 use Test::More tests => 24;
-
 
 my %tests = (
     1989 => {


### PR DESCRIPTION
```perl
use utf8;
```

single script 에서 `utf8` pragma 를 켜두고 쓰면 문제가 없는 것 같은데,

<img width="500" alt="2018-10-06 2 37 44" src="https://user-images.githubusercontent.com/170528/46567830-6f45c480-c975-11e8-8d22-21aec8573fe4.png">

mojo app 에서는 요딴식으로 나옵니다.
그동안 쉬는날 목록만 뽑아써서 꿀 잘 빨았는데, 그날이 무슨날이지 확인해보려니 이렇습니다.

🙇 부디 머지후에 배포하여주세요.